### PR TITLE
Extend run.sh

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -5,22 +5,58 @@ normal="\033[0m"
 
 BASE_DIR=$(dirname "$0")
 
-if [[ ! -z "$1" ]]; then
-  if [[ ! -d "$BASE_DIR/../examples/$1" ]]; then
+get_help() {
+  echo "Usage: $0 <options> <example_name>"
+  echo "example_name:"
+  echo "  - name of the example to run"
+  echo "  - run '$0 -l' to list available examples"
+  echo "  - if not provided, all examples will be run"
+  echo "Options:"
+  echo "  -l: list available examples"
+  echo "  -h: show this help"
+  exit 0
+}
+
+print_examples() {
+  echo "Available examples:"
+  for i in "$BASE_DIR"/../examples/*;
+  do
+    IFS="/" read -ra string <<< "$i"
+    echo "  - ${string[-1]}"
+  done
+}
+
+execute_example() {
+  folder_name="${1,,}"
+
+  if [[ ! -d "$BASE_DIR/../examples/$folder_name" ]]; then
     echo "Example '$1' does not exist"
     exit 1
   fi
 
-  heading="Example - ${$1^}"
+  IFS=- read -ra example_name <<< "$1"
+
+  heading="Example - ${example_name[*]^}"
   echo -e "$heading_color$heading$normal"
   go run "$BASE_DIR/../examples/$1/main.go"
-  exit 0
-fi
+}
 
-for i in "$BASE_DIR"/../examples/*;
-do
-  IFS="/" read -ra string <<< "$i"
-  heading="Example - ${string[-1]^}"
-  echo -e "$heading_color$heading$normal"
-  go run "$i/main.go"
-done
+execute_all_examples() {
+  for i in "$BASE_DIR"/../examples/*;
+  do
+    IFS="/" read -ra string <<< "$i"
+    heading="Example - ${string[-1]^}"
+    echo -e "$heading_color$heading$normal"
+    go run "$i/main.go"
+  done
+}
+
+if [[ "$1" == "-h" ]]; then
+  get_help
+elif [[ "$1" == "-l" ]]; then
+  print_examples
+elif [[ ! -z "$1" ]]; then
+  execute_example "$1"
+elif [[ -z "$1" ]]; then
+  execute_all_examples
+fi


### PR DESCRIPTION
- Fix bad substitution error when running single example

- Add '-h' for help

- Add '-l' for list available examples

- Decouple argument check from actions