### PR TITLE
Add a new example

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,26 @@ git clone https://github.com/KytnaCode/go-context-examples.git
 cd go-context-examples
 ```
 ### Run the examples from Linux/macOS
-Just run the following command:
+Run the following command to run all the examples:
 ```bash
 chmod +x ./scripts/run.sh
 ./scripts/run.sh
 ```
 
+for get help run:
+```bash
+./scripts/run.sh -h
+```
+
 > Note: If you only want to run a specific example, you can run the following command:
+>
+> for get examples list run:
+> ```bash
+> ./scripts/run.sh -l
+> ```
+> 
+> then run:
+> 
 > ```bash
 > ./scripts/run.sh <example>
 > ```

--- a/examples/cancel/README.md
+++ b/examples/cancel/README.md
@@ -1,0 +1,86 @@
+# go-context-examples - Cancel
+
+In this example, we will create a context that can be canceled using the `context.WithCancel()` function.
+
+## Why use `context.WithCancel()`?
+
+The `context.WithCancel()` function is used when you want to create a context that can be canceled. This is useful when you want to cancel a request or a function call, depending on the context.
+
+## Run the example
+
+There's two ways to run the example. 
+
+### First way, using the `run.sh` script
+
+Go to the root of the repository and run the following command:
+
+```bash
+./scripts/run.sh cancel
+```
+
+or for running all the examples:
+
+```bash
+./scripts/run.sh
+```
+
+> Note: If you want to run the example from Windows, use the second way.
+
+### Second way, using `go run`
+
+To run the example, either bash or batch, run the following command:
+
+```bash
+go run main.go
+```
+
+## General Pseudo Code
+
+```
+MAIN
+    Create base context
+    Create context with cancel
+    SomeFunction(Context)
+    
+    ...
+    
+    Cancel context
+    SomeFunction returns
+   
+SomeFunction(Context)
+    Do something
+    Wait for context to be canceled
+    Interrupt the function
+```
+
+## Example code
+```go
+package main
+
+import (
+    "context"
+    "fmt"
+    "time"
+)
+
+func main() {
+    baseCtx := context.Background()
+
+    ctx, cancel := context.WithCancel(baseCtx) 
+
+    go SomeFunction(ctx)
+
+    time.Sleep(1 * time.Second)
+
+    cancel()
+}
+
+func SomeFunction(ctx context.Context) {
+    fmt.Println("Doing something")
+
+    select {
+    case <-ctx.Done():
+        fmt.Println("Context canceled")
+    }
+}
+```

--- a/examples/cancel/main.go
+++ b/examples/cancel/main.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+func doSomething(ctx context.Context) {
+	// create a context with cancel
+	ctx, cancel := context.WithCancel(ctx)
+
+	// create a channel to print
+	printCh := make(chan int)
+	go doAnother(ctx, printCh)
+
+	// send 1, 2, 3 to printCh
+	for num := 1; num <= 3; num++ {
+		time.Sleep(25 * time.Millisecond)
+		printCh <- num
+	}
+
+	// cancel the context, this will stop the doAnother goroutine
+	cancel()
+
+	time.Sleep(100 * time.Millisecond)
+	fmt.Println("doSomething: finished")
+}
+
+func doAnother(ctx context.Context, printCh <-chan int) {
+	// loop until ctx is done
+	for {
+		select {
+		// if ctx is done, return
+		case <-ctx.Done():
+			if err := ctx.Err(); err != nil {
+				fmt.Printf("doAnother err: %s\n", err)
+			}
+			fmt.Println("doAnother: finished")
+			return
+		// if printCh has value, print it
+		case num := <-printCh:
+			fmt.Printf("doAnother: %d\n", num)
+		}
+	}
+}
+
+func main() {
+	// create an empty context
+	ctx := context.Background()
+
+	doSomething(ctx)
+}


### PR DESCRIPTION
# Add new example - 'cancel' example

Add a new example using `context.WithCancel()` 

The example includes the following:
- An example go program
- An example primary go code in README.md
- A pseudocode of how to use `context.WithCancel()`